### PR TITLE
update generate_signed_url

### DIFF
--- a/ckanext/cloudstorage/google_storage.py
+++ b/ckanext/cloudstorage/google_storage.py
@@ -2,109 +2,134 @@ import binascii
 import collections
 import datetime
 import hashlib
-import json
-
-# pip install google-auth
-from google.auth import crypt
-# pip install six==1.5
-import six
 from six.moves.urllib.parse import quote
 
-# https://cloud.google.com/storage/docs/access-control/signing-urls-manually
-def generate_signed_url(service_account_email, private_key_file, bucket_name, object_name,
-                        subresource=None, expiration=604800, http_method='GET',
-                        query_parameters=None, headers=None):
+# Required for Google Cloud authentication
+from google.oauth2 import service_account
 
+# Required for handling Python 2 and 3 compatibility issues
+import six
+
+def generate_signed_url(
+    service_account_file,  # Path to the service account file
+    bucket_name,           # Name of the GCS bucket
+    object_name,           # Name of the object in the bucket
+    subresource=None,      # Optional subresource of the object
+    expiration=604800,     # Expiration time of the URL in seconds (default 7 days)
+    http_method="GET",     # HTTP method for the access (default GET)
+    query_parameters=None, # Additional query parameters for the URL
+    headers=None           # HTTP headers for the request
+):
+    """
+    Generate a signed URL to access a Google Cloud Storage object.
+
+    This function creates a signed URL that provides temporary access to a specific object
+    in a Google Cloud Storage bucket. The URL will be valid for the specified duration.
+
+    Args:
+        service_account_file (str): Path to the service account JSON file.
+        bucket_name (str): Name of the Google Cloud Storage bucket.
+        object_name (str): Name of the object in the bucket.
+        subresource (str, optional): Subresource of the object, if any. Defaults to None.
+        expiration (int, optional): Time in seconds until the URL expires. Defaults to 604800 (7 days).
+        http_method (str, optional): HTTP method for the access. Defaults to "GET".
+        query_parameters (dict, optional): Additional query parameters. Defaults to None.
+        headers (dict, optional): HTTP headers for the request. Defaults to None.
+
+    Returns:
+        str: A signed URL for accessing the specified storage object.
+
+    Raises:
+        ValueError: If the expiration time exceeds 7 days (604800 seconds).
+    """
+
+    # Validate expiration time
     if expiration > 604800:
-        raise Exception('Expiration Time can\'t be longer than 604800 seconds (7 days).')
+        raise ValueError("Expiration time can't be longer than 604800 seconds (7 days).")
 
-    escaped_object_name = quote(six.ensure_binary(object_name), safe=b'/~')
-    canonical_uri = '/{}'.format(escaped_object_name)
+    # Encode the object name for URL
+    escaped_object_name = quote(six.ensure_binary(object_name), safe=b"/~")
+    canonical_uri = "/{}".format(escaped_object_name)
 
+    # Get the current time in UTC
     datetime_now = datetime.datetime.utcnow()
     request_timestamp = datetime_now.strftime('%Y%m%dT%H%M%SZ')
     datestamp = datetime_now.strftime('%Y%m%d')
 
-    client_email = service_account_email
+    # Load Google credentials
+    google_credentials = service_account.Credentials.from_service_account_file(
+        service_account_file
+    )
+    client_email = google_credentials.service_account_email
+    credential_scope = "{}/auto/storage/goog4_request".format(datestamp)
+    credential = "{}/{}".format(client_email, credential_scope)
 
-    credential_scope = '{}/auto/storage/goog4_request'.format(datestamp)
-    credential = '{}/{}'.format(client_email, credential_scope)
-
+    # Set default headers if not provided
     if headers is None:
         headers = dict()
-    host = '{}.storage.googleapis.com'.format(bucket_name)
-    headers['host'] = host
+    host = "{}.storage.googleapis.com".format(bucket_name)
+    headers["host"] = host
 
-    canonical_headers = ''
+    # Create canonical headers string
+    canonical_headers = ""
     ordered_headers = collections.OrderedDict(sorted(headers.items()))
     for k, v in ordered_headers.items():
         lower_k = str(k).lower()
-        strip_v = str(v).lower()
-        canonical_headers += '{}:{}\n'.format(lower_k, strip_v)
+        strip_v = str(v).strip()
+        canonical_headers += "{}:{}\n".format(lower_k, strip_v)
 
-    signed_headers = ''
-    for k, _ in ordered_headers.items():
-        lower_k = str(k).lower()
-        signed_headers += '{};'.format(lower_k)
-    signed_headers = signed_headers[:-1]  # remove trailing ';'
+    # Create signed headers string
+    signed_headers = ";".join(ordered_headers.keys()).lower()
 
+    # Set default query parameters if not provided
     if query_parameters is None:
         query_parameters = dict()
-    query_parameters['X-Goog-Algorithm'] = 'GOOG4-RSA-SHA256'
-    query_parameters['X-Goog-Credential'] = credential
-    query_parameters['X-Goog-Date'] = request_timestamp
-    query_parameters['X-Goog-Expires'] = expiration
-    query_parameters['X-Goog-SignedHeaders'] = signed_headers
+    query_parameters.update({
+        "X-Goog-Algorithm": "GOOG4-RSA-SHA256",
+        "X-Goog-Credential": credential,
+        "X-Goog-Date": request_timestamp,
+        "X-Goog-Expires": str(expiration),
+        "X-Goog-SignedHeaders": signed_headers
+    })
     if subresource:
-        query_parameters[subresource] = ''
+        query_parameters[subresource] = ""
 
-    canonical_query_string = ''
-    ordered_query_parameters = collections.OrderedDict(
-        sorted(query_parameters.items()))
-    for k, v in ordered_query_parameters.items():
-        encoded_k = quote(str(k), safe='')
-        encoded_v = quote(str(v), safe='')
-        canonical_query_string += '{}={}&'.format(encoded_k, encoded_v)
-    canonical_query_string = canonical_query_string[:-1]  # remove trailing '&'
+    # Create canonical query string
+    canonical_query_string = "&".join(
+        "{}={}".format(quote(str(k), safe=''), quote(str(v), safe=''))
+        for k, v in sorted(query_parameters.items())
+    ).rstrip('&')
 
-    canonical_request = '\n'.join([http_method,
-                                   canonical_uri,
-                                   canonical_query_string,
-                                   canonical_headers,
-                                   signed_headers,
-                                   'UNSIGNED-PAYLOAD'])
+    # Create canonical request
+    canonical_request = "\n".join([
+        http_method,
+        canonical_uri,
+        canonical_query_string,
+        canonical_headers,
+        signed_headers,
+        "UNSIGNED-PAYLOAD",
+    ])
 
-    canonical_request_hash = hashlib.sha256(
-        canonical_request.encode()).hexdigest()
+    # Hash the canonical request
+    canonical_request_hash = hashlib.sha256(canonical_request.encode()).hexdigest()
 
-    string_to_sign = '\n'.join(['GOOG4-RSA-SHA256',
-                                request_timestamp,
-                                credential_scope,
-                                canonical_request_hash])
+    # Create the string to sign
+    string_to_sign = "\n".join([
+        "GOOG4-RSA-SHA256",
+        request_timestamp,
+        credential_scope,
+        canonical_request_hash,
+    ])
 
-    keydata = None
-    # TODO MOVE TO INITIALIZATION
-    # signer.sign() signs using RSA-SHA256 with PKCS1v15 padding
-    with open(private_key_file) as private_key:
-        keydata = private_key.read()
-
-    if not keydata:
-        raise Exception('Unable to load private key file')
-
-    # Convert the string to a dictionary
-    keydata_dict = json.loads(keydata)
-
-    # Extract the private key string
-    private_key = keydata_dict["private_key"]
-        
-    signer = crypt.RSASigner.from_string(private_key)
-
+    # Sign the string to sign using the service account's private key
     signature = binascii.hexlify(
-        signer.sign(string_to_sign)
+        google_credentials.signer.sign(string_to_sign.encode())
     ).decode()
 
-    scheme_and_host = '{}://{}'.format('https', host)
-    signed_url = '{}{}?{}&x-goog-signature={}'.format(
-        scheme_and_host, canonical_uri, canonical_query_string, signature)
+    # Construct the final signed URL
+    scheme_and_host = "https://{}".format(host)
+    signed_url = "{}{}?{}&x-goog-signature={}".format(
+        scheme_and_host, canonical_uri, canonical_query_string, signature
+    )
 
     return signed_url

--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -373,7 +373,6 @@ class ResourceCloudStorage(CloudStorage):
             obj=self.container.get_object(path)
 
             return storage.generate_signed_url(
-                self.driver_options['key'],
                 self.driver_options['secret'],
                 self.container_name,
                 object_name=obj.name,


### PR DESCRIPTION
This updated version generates a signed URL using Google **Cloud's service_account** module for credential handling , while the second script manually loads and uses a **private key** `with google.auth.crypt.RSASigner` for signing, reflecting a more hands-on approach to key management.